### PR TITLE
Refactor CorruptionMenu rendering logic

### DIFF
--- a/src/main/java/elocindev/eldritch_end/mixin/client/screen/CorruptionMenuRenderMixin.java
+++ b/src/main/java/elocindev/eldritch_end/mixin/client/screen/CorruptionMenuRenderMixin.java
@@ -25,8 +25,8 @@ public abstract class CorruptionMenuRenderMixin extends AbstractInventoryScreen<
 
     public ItemStack dummy = new ItemStack(ItemRegistry.CORRUPTION_MENU);
 
-    @Inject(method = "drawBackground", at = @At("TAIL"), cancellable = true)
-    protected void drawBackground(DrawContext context, float delta, int mouseX, int mouseY, CallbackInfo info) {  
+    @Inject(method = "render", at = @At("TAIL"))
+    protected void render(DrawContext context, int mouseX, int mouseY, float delta, CallbackInfo info) {
         String texturePath = "textures/icon/corruption_menu/";
         long currentTime = System.currentTimeMillis();
         long animationCycle = 200;


### PR DESCRIPTION
This improves compatibility with mods that modify the interface such as inventory profiles next.

Without this change, interface elements such as the buttons from inventory profile next can be on top of the tool tip.