### PR TITLE
Fix: Preserve Infusions during Smithing Upgrades

### DIFF
--- a/src/main/java/elocindev/eldritch_end/mixin/recipe/SmithingTransformRecipeMixin.java
+++ b/src/main/java/elocindev/eldritch_end/mixin/recipe/SmithingTransformRecipeMixin.java
@@ -1,0 +1,30 @@
+package elocindev.eldritch_end.mixin.recipe;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import net.minecraft.inventory.Inventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.recipe.SmithingTransformRecipe;
+import net.minecraft.registry.DynamicRegistryManager;
+
+@Mixin(SmithingTransformRecipe.class)
+public class SmithingTransformRecipeMixin {
+    @Inject(method = "finishRecipe", at = @At("RETURN"))
+    private void eldritch_end$keepInfusions(Inventory inventory, DynamicRegistryManager registryManager, CallbackInfoReturnable<ItemStack> cir) {
+        ItemStack result = cir.getReturnValue();
+        ItemStack base = inventory.getStack(1); // SmithingTransformRecipe.base is at index 1 in the inventory
+
+        if (base.hasNbt() && base.getNbt().contains("eldritch_infusions")) {
+            NbtCompound infusions = base.getSubNbt("eldritch_infusions").copy();
+            result.getOrCreateNbt().put("eldritch_infusions", infusions);
+            
+            if (base.getNbt().contains("AttributeModifiers")) {
+                result.getNbt().put("AttributeModifiers", base.getNbt().get("AttributeModifiers").copy());
+            }
+        }
+    }
+}

--- a/src/main/resources/eldritch_end.mixins.json
+++ b/src/main/resources/eldritch_end.mixins.json
@@ -15,7 +15,8 @@
     "entity.attribute.AttributeApplyMixin",
     "entity.attribute.CorruptionDamageMixin",
     "smithing.ForgingScreenHandlerAccessor",
-    "smithing.InfusionSmithingTableMixin"
+    "smithing.InfusionSmithingTableMixin",
+    "recipe.SmithingTransformRecipeMixin"
   ],
   "client": [
     "client.BackgroundRendererMixin",


### PR DESCRIPTION
This PR fixes a bug where custom Eldritch Infusions (NBT data and attribute modifiers) were lost when an item was upgraded using a smithing transformation recipe (e.g., Diamond to Netherite). It adds a Mixin to copy the necessary NBT tags from the base item to the result.