### PR TITLE
Fix: replace attribute baking with dynamic injection in infusion system

### DIFF
--- a/src/main/java/elocindev/eldritch_end/mixin/item/InfusionItemAttributeMixin.java
+++ b/src/main/java/elocindev/eldritch_end/mixin/item/InfusionItemAttributeMixin.java
@@ -1,0 +1,75 @@
+package elocindev.eldritch_end.mixin.item;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+
+import elocindev.eldritch_end.api.infusion.InfusableItemMaterial;
+import net.minecraft.entity.EquipmentSlot;
+import net.minecraft.entity.attribute.EntityAttribute;
+import net.minecraft.entity.attribute.EntityAttributeModifier;
+import net.minecraft.item.ArmorItem;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.registry.Registries;
+import net.minecraft.util.Identifier;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(ItemStack.class)
+public class InfusionItemAttributeMixin {
+
+    @Inject(method = "getAttributeModifiers", at = @At("RETURN"), cancellable = true)
+    private void eldritch_end$applyInfusionAttributes(EquipmentSlot slot, CallbackInfoReturnable<Multimap<EntityAttribute, EntityAttributeModifier>> cir) {
+
+        ItemStack self = (ItemStack) (Object) this;
+
+        NbtCompound infusionNbt = self.getSubNbt("eldritch_infusions");
+        if (infusionNbt == null || !infusionNbt.getBoolean("isInfused")) return;
+
+        if (self.hasNbt() && self.getNbt().contains("AttributeModifiers")) return;
+
+        String materialId = infusionNbt.getString("materialIdentifier");
+        if (materialId == null || materialId.isEmpty()) return;
+
+        Identifier id;
+        try {
+            id = new Identifier(materialId);
+        } catch (Exception e) {
+            return;
+        }
+
+        Item materialItem = Registries.ITEM.get(id);
+        if (!(materialItem instanceof InfusableItemMaterial material)) return;
+
+        EquipmentSlot itemSlot;
+        if (self.getItem() instanceof ArmorItem armorItem) {
+            itemSlot = armorItem.getSlotType();
+        } else if (infusionNbt.contains("infusionSlot")) {
+            itemSlot = EquipmentSlot.byName(infusionNbt.getString("infusionSlot"));
+        } else {
+            itemSlot = EquipmentSlot.MAINHAND;
+        }
+
+        if (slot != itemSlot) return;
+
+        Multimap<EntityAttribute, EntityAttributeModifier> modifiers = HashMultimap.create(cir.getReturnValue());
+
+        ItemStack dummyMaterialStack = new ItemStack(materialItem);
+
+        for (var holder : material.getInfusionAttributes()) {
+            EntityAttributeModifier modifier = new EntityAttributeModifier(
+                    material.getInfusionUUID(dummyMaterialStack, slot),
+                    "Infusion modifier",
+                    holder.amount,
+                    holder.operation
+            );
+            modifiers.put(holder.attribute, modifier);
+        }
+
+        cir.setReturnValue(modifiers);
+    }
+}

--- a/src/main/java/elocindev/eldritch_end/mixin/smithing/InfusionSmithingTableMixin.java
+++ b/src/main/java/elocindev/eldritch_end/mixin/smithing/InfusionSmithingTableMixin.java
@@ -1,6 +1,5 @@
 package elocindev.eldritch_end.mixin.smithing;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.function.Predicate;
 
@@ -12,30 +11,22 @@ import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Multimap;
-
 import elocindev.eldritch_end.api.infusion.InfusableItemMaterial;
 import elocindev.eldritch_end.api.infusion.InfusionTemplate;
-import elocindev.eldritch_end.mixin.item.ItemAttributeAccessor;
-import net.minecraft.entity.EquipmentSlot;
-import net.minecraft.entity.attribute.EntityAttribute;
-import net.minecraft.entity.attribute.EntityAttributeModifier;
-import net.minecraft.entity.attribute.EntityAttributes;
-import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ArmorItem;
 import net.minecraft.item.AxeItem;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.SwordItem;
 import net.minecraft.item.ToolItem;
 import net.minecraft.nbt.NbtCompound;
+import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.registry.Registries;
 import net.minecraft.screen.SmithingScreenHandler;
 import net.minecraft.screen.slot.Slot;
 
 @Mixin(SmithingScreenHandler.class)
 public class InfusionSmithingTableMixin {
-    @Shadow 
+    @Shadow
     private List<ItemStack> getInputStacks() {
         return null;
     }
@@ -58,7 +49,6 @@ public class InfusionSmithingTableMixin {
 
                 break;
             default:
-                return;
         }        
     }
 
@@ -75,11 +65,7 @@ public class InfusionSmithingTableMixin {
         return original.or(stack -> {
             if (!(getMaterial().getItem() instanceof InfusableItemMaterial) || !(getTemplate().getItem() instanceof InfusionTemplate template)) return false;
 
-            if (template.isEquipmentAllowed((ItemStack) stack)) {
-                return true;
-            }
-
-            return false;
+            return template.isEquipmentAllowed((ItemStack) stack);
         });
     }
 
@@ -93,13 +79,7 @@ public class InfusionSmithingTableMixin {
         index = 3
     )
     private Predicate<?> eldritch_end$modifyAdditionSlotCondition(Predicate<?> original) {
-        return original.or(stack -> {
-            if (((ItemStack) stack).getItem() instanceof InfusableItemMaterial) {
-                return true;
-            }
-
-            return false;
-        });
+        return original.or(stack -> ((ItemStack) stack).getItem() instanceof InfusableItemMaterial);
     }
     
     @Inject(method = "updateResult", at = @At("HEAD"), cancellable = true)
@@ -117,102 +97,28 @@ public class InfusionSmithingTableMixin {
             if (candidate.getItem() instanceof ArmorItem && !material.applyToArmor()
             || (candidate.getItem() instanceof SwordItem || candidate.getItem() instanceof AxeItem || candidate.getItem() instanceof ToolItem) && !material.applyToWeapons()
             || (!material.isInfusable())) return;
-    
+
             boolean isAlreadyInfused = candidate.copy().getOrCreateSubNbt("eldritch_infusions").getBoolean("isInfused");
     
             if (isAlreadyInfused && (!isUpgradeable(material, candidate.copy()))) return;
     
             ItemStack potentialResult = candidate.copy();
-    
-            NbtCompound nbt = potentialResult.getOrCreateSubNbt("eldritch_infusions");
-    
-            EquipmentSlot slot;
-    
-            if (potentialResult.getItem() instanceof ArmorItem armorItem) {
-                slot = armorItem.getSlotType();
-            // } else if (potentialResult.getItem() instanceof SwordItem || potentialResult.getItem() instanceof AxeItem) {
-            //     slot = EquipmentSlot.MAINHAND;
-            } else {
-                slot = EquipmentSlot.MAINHAND;
+
+            if (potentialResult.hasNbt() && potentialResult.getNbt() != null) {
+                potentialResult.getNbt().remove("AttributeModifiers");
             }
-    
+
+            NbtCompound nbt = potentialResult.getOrCreateSubNbt("eldritch_infusions");
+
             nbt.putBoolean("isInfused", true);
             nbt.putString("currentInfusion", Registries.ITEM.getId(addition.getItem()).getPath());
             nbt.putString("materialIdentifier", Registries.ITEM.getId(addition.getItem()).toString());
-            
-            Multimap<EntityAttribute, EntityAttributeModifier> originalModifiers = HashMultimap.create();
-            originalModifiers.putAll(potentialResult.getAttributeModifiers(slot));
-            
-            Multimap<EntityAttribute, EntityAttributeModifier> mergedModifiers = HashMultimap.create(originalModifiers);
-            
-            for (var holder : material.getInfusionAttributes()) {
-                EntityAttributeModifier newModifier = new EntityAttributeModifier(
-                    material.getInfusionUUID(addition, slot),
-                    "Infusion modifier",
-                    holder.amount,
-                    holder.operation
-                );
-    
-                if (holder.attribute.equals(EntityAttributes.GENERIC_ATTACK_DAMAGE) || holder.attribute.equals(EntityAttributes.GENERIC_ATTACK_SPEED)) {
-                    Collection<EntityAttributeModifier> existingModifiers = mergedModifiers.get(holder.attribute);
-                    EntityAttributeModifier toReplace = null;
-    
-                    for (EntityAttributeModifier existingModifier : existingModifiers) {
-                        if (existingModifier.getId().equals(newModifier.getId())) {
-                            toReplace = existingModifier;
-                            break;
-                        }
-                    }
-    
-                    if (toReplace != null) {
-                        mergedModifiers.remove(holder.attribute, toReplace);
-                        mergedModifiers.put(holder.attribute, new EntityAttributeModifier(
-                            toReplace.getId(),
-                            toReplace.getName(),
-                            toReplace.getValue() + newModifier.getValue(),
-                            toReplace.getOperation()
-                        ));
-                    } else {
-                        mergedModifiers.put(holder.attribute, newModifier);
-                    }
-                } else {
-                    mergedModifiers.put(holder.attribute, newModifier);
-                }
-            }
-    
-            boolean useWeaponModifiers = !(potentialResult.getItem() instanceof ArmorItem);
-    
-            for (var entry : mergedModifiers.entries()) {
-                EntityAttribute attribute = entry.getKey();
-                EntityAttributeModifier modifier = entry.getValue();
-    
-                if (attribute.equals(EntityAttributes.GENERIC_ATTACK_DAMAGE)) {
-                    modifier = new EntityAttributeModifier(
-                        useWeaponModifiers ? ItemAttributeAccessor.getAttackDamageModifierId() : modifier.getId(),
-                        modifier.getName(),
-                        modifier.getValue(),
-                        modifier.getOperation()
-                    );
-                } else if (attribute.equals(EntityAttributes.GENERIC_ATTACK_SPEED)) {
-                    modifier = new EntityAttributeModifier(
-                        useWeaponModifiers ? ItemAttributeAccessor.getAttackSpeedModifierId() : modifier.getId(),
-                        modifier.getName(),
-                        modifier.getValue(),
-                        modifier.getOperation()
-                    );
-                }
-    
-                potentialResult.addAttributeModifier(attribute, modifier, slot);
-            }
-    
+
             ((ForgingScreenHandlerAccessor) ths).getOutput().setStack(3, potentialResult);
     
             ci.cancel();
         }
     }
-    
-
-
 
     @Inject(method = "canTakeOutput", at = @At("HEAD"), cancellable = true)
     private void canTakeOutput(PlayerEntity player, boolean present, CallbackInfoReturnable<Boolean> cir) {

--- a/src/main/resources/eldritch_end.mixins.json
+++ b/src/main/resources/eldritch_end.mixins.json
@@ -4,18 +4,19 @@
   "package": "elocindev.eldritch_end.mixin",
   "compatibilityLevel": "JAVA_17",
   "mixins": [
-    "worldgen.EntFixerMixin",
-    "worldgen.biome.SurfaceRuleAccessor",
+    "boat.BoatTypeMixin",
+    "entity.attribute.AttributeApplyMixin",
+    "entity.attribute.CorruptionDamageMixin",
+    "item.InfusionItemAttributeMixin",
+    "item.ItemAttributeAccessor",
+    "item.ItemNameMixin",
     "server.BiomeMixin",
     "server.ServerWorldMixin",
     "sign.BlockEntityTypeMixin",
-    "boat.BoatTypeMixin",
-    "item.ItemNameMixin",
-    "item.ItemAttributeAccessor",
-    "entity.attribute.AttributeApplyMixin",
-    "entity.attribute.CorruptionDamageMixin",
     "smithing.ForgingScreenHandlerAccessor",
-    "smithing.InfusionSmithingTableMixin"
+    "smithing.InfusionSmithingTableMixin",
+    "worldgen.EntFixerMixin",
+    "worldgen.biome.SurfaceRuleAccessor"
   ],
   "client": [
     "client.BackgroundRendererMixin",


### PR DESCRIPTION
## Bugs
- Infused items keep the same stats after smithing upgrade (e.g. diamond to netherite)
- Additional stats / attributes are not handled correctly and fill the item's NBT data, making it incompatible with mods such as Tierify

## Fixes
- InfusionSmithingTableMixin.updateResult no longer writes any attribute modifiers. It only writes the infusion metadata (isInfused, currentInfusion, materialIdentifier). The actual attribute bonuses are now applied dynamically.
- A new mixin, InfusionItemAttributeMixin, was created to fix the attribute handling. It reads the eldritch_infusions NBT compound and adds the infusion bonuses on top of whatever the item already returned.
Legacy items (infused before this patch) are detected and the mixin skips dynamic injection for them, so they continue working exactly as before.